### PR TITLE
Support for Shipmondo (Pakkelabels.dk)

### DIFF
--- a/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
+++ b/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
@@ -53,9 +53,15 @@ jQuery(function ($) {
                     return false;
                 }
                 
-                // Shipmondo: Business shipping, but no business name
-                if ($('#shipping_method input:checked').val() == 'pakkelabels_shipping_postnord_business' && $("#billing_company").val() == '') {
-                    return false;
+                //Shipmondo: Business shipping, but no business name
+                var shipmondoBusinessTypes = [
+					"pakkelabels_shipping_gls_business",
+					"pakkelabels_shipping_postnord_business",
+					"pakkelabels_shipping_bring_business"
+				];
+				
+                if(shipmondoBusinessTypes.includes($('#shipping_method input:checked').val()) && $("#billing_company").val() == ''){
+					return false;
                 }
 
                 // Shipmondo: Pickup point shipping, but no pickup point selected

--- a/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
+++ b/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
@@ -55,13 +55,13 @@ jQuery(function ($) {
                 
                 //Shipmondo: Business shipping, but no business name
                 var shipmondoBusinessTypes = [
-					"pakkelabels_shipping_gls_business",
-					"pakkelabels_shipping_postnord_business",
-					"pakkelabels_shipping_bring_business"
-				];
-				
+                    "pakkelabels_shipping_gls_business",
+                    "pakkelabels_shipping_postnord_business",
+                    "pakkelabels_shipping_bring_business"
+                ];
+                
                 if(shipmondoBusinessTypes.includes($('#shipping_method input:checked').val()) && $("#billing_company").val() == ''){
-					return false;
+                    return false;
                 }
 
                 // Shipmondo: Pickup point shipping, but no pickup point selected

--- a/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
+++ b/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
@@ -73,6 +73,8 @@ jQuery(function ($) {
                         return false;
                     }
                 }
+                
+                if (!wc_paylike_form.validateShipmondo()) return false;
 
                 return true;
             },
@@ -134,7 +136,6 @@ jQuery(function ($) {
                 return wc_paylike_form.escapeQoutes(phone);
             },
             onSubmit: function (e) {
-                if (!wc_paylike_form.validateShipmondo()) return true;
                 if (wc_paylike_form.isPaylikeModalNeeded()) {
                     e.preventDefault();
 

--- a/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
+++ b/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
@@ -55,19 +55,19 @@ jQuery(function ($) {
                 
                 // Shipmondo: Business shipping, but no business name
                 if ($('#shipping_method input:checked').val() == 'pakkelabels_shipping_postnord_business' && $("#billing_company").val() == '') {
-					return false;
+                    return false;
                 }
 
-				// Shipmondo: Pickup point shipping, but no pickup point selected
-				var shipmondoPickupPointTypes = [
-					"pakkelabels_shipping_gls",
-					"pakkelabels_shipping_pdk",
-					"pakkelabels_shipping_dao",
-					"pakkelabels_shipping_bring"
-				];
-				
-				if (shipmondoPickupPointTypes.includes($('#shipping_method input:checked').val()) && $("#hidden_chosen_shop input[name='shop_ID']").val() == '') {
-					return false;
+                // Shipmondo: Pickup point shipping, but no pickup point selected
+                var shipmondoPickupPointTypes = [
+                    "pakkelabels_shipping_gls",
+                    "pakkelabels_shipping_pdk",
+                    "pakkelabels_shipping_dao",
+                    "pakkelabels_shipping_bring"
+                ];
+                
+                if (shipmondoPickupPointTypes.includes($('#shipping_method input:checked').val()) && $("#hidden_chosen_shop input[name='shop_ID']").val() == '') {
+                    return false;
                 }
 
                 // check to see if we need to validate shipping address

--- a/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
+++ b/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
@@ -134,7 +134,7 @@ jQuery(function ($) {
                 return wc_paylike_form.escapeQoutes(phone);
             },
             onSubmit: function (e) {
-	            if (!wc_paylike_form.validateShipmondo()) return true;
+                if (!wc_paylike_form.validateShipmondo()) return true;
                 if (wc_paylike_form.isPaylikeModalNeeded()) {
                     e.preventDefault();
 
@@ -221,38 +221,38 @@ jQuery(function ($) {
                 return str.toString().replace(/"/g, '\\"');
             },
             validateShipmondo:function() {
-	            
-	            // Check if Shipmondo (Pakkelabels.dk) shipping option is selected
-	            if ($('#shipping_method input:checked').val().indexOf("pakkelabels") >= 0) {
-		            
-					// Business shipping, but no business name
-	                var shipmondoBusinessTypes = [
-	                    "pakkelabels_shipping_gls_business",
-	                    "pakkelabels_shipping_postnord_business",
-	                    "pakkelabels_shipping_bring_business"
-	                ];
-	                
-	                if (shipmondoBusinessTypes.includes($('#shipping_method input:checked').val()) && $("#billing_company").val() == '') {
-	                    return false;
-	                }
-	
-					// Pickup point shipping, but no pickup point selected
-	                var shipmondoPickupPointTypes = [
-	                    "pakkelabels_shipping_gls",
-	                    "pakkelabels_shipping_pdk",
-	                    "pakkelabels_shipping_dao",
-	                    "pakkelabels_shipping_bring"
-	                ];
-	                
-					// Check if pickup point shipping is selected
-	                if (shipmondoPickupPointTypes.includes($('#shipping_method input:checked').val())) {
-						// Check if a shopID exists
-		                if ($("#hidden_chosen_shop input[name='shop_ID']").val() == '') {
-	                    	return false;
-	                    }
-	                }
-	                
-	            }
+                
+                // Check if Shipmondo (Pakkelabels.dk) shipping option is selected
+                if ($('#shipping_method input:checked').val().indexOf("pakkelabels") >= 0) {
+                    
+                    // Business shipping, but no business name
+                    var shipmondoBusinessTypes = [
+                        "pakkelabels_shipping_gls_business",
+                        "pakkelabels_shipping_postnord_business",
+                        "pakkelabels_shipping_bring_business"
+                    ];
+                    
+                    if (shipmondoBusinessTypes.includes($('#shipping_method input:checked').val()) && $("#billing_company").val() == '') {
+                        return false;
+                    }
+    
+                    // Pickup point shipping, but no pickup point selected
+                    var shipmondoPickupPointTypes = [
+                        "pakkelabels_shipping_gls",
+                        "pakkelabels_shipping_pdk",
+                        "pakkelabels_shipping_dao",
+                        "pakkelabels_shipping_bring"
+                    ];
+                    
+                    // Check if pickup point shipping is selected
+                    if (shipmondoPickupPointTypes.includes($('#shipping_method input:checked').val())) {
+                        // Check if a shopID exists
+                        if ($("#hidden_chosen_shop input[name='shop_ID']").val() == '') {
+                            return false;
+                        }
+                    }
+                    
+                }
                 
                 return true;
 

--- a/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
+++ b/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
@@ -52,30 +52,7 @@ jQuery(function ($) {
                 if ($('#createaccount').is(':checked') && $account_password.length && $account_password.val() === '') {
                     return false;
                 }
-                
-                //Shipmondo: Business shipping, but no business name
-                var shipmondoBusinessTypes = [
-                    "pakkelabels_shipping_gls_business",
-                    "pakkelabels_shipping_postnord_business",
-                    "pakkelabels_shipping_bring_business"
-                ];
-                
-                if(shipmondoBusinessTypes.includes($('#shipping_method input:checked').val()) && $("#billing_company").val() == ''){
-                    return false;
-                }
-
-                // Shipmondo: Pickup point shipping, but no pickup point selected
-                var shipmondoPickupPointTypes = [
-                    "pakkelabels_shipping_gls",
-                    "pakkelabels_shipping_pdk",
-                    "pakkelabels_shipping_dao",
-                    "pakkelabels_shipping_bring"
-                ];
-                
-                if (shipmondoPickupPointTypes.includes($('#shipping_method input:checked').val()) && $("#hidden_chosen_shop input[name='shop_ID']").val() == '') {
-                    return false;
-                }
-
+                                
                 // check to see if we need to validate shipping address
                 if ($('#ship-to-different-address-checkbox').is(':checked')) {
                     $required_inputs = $('.woocommerce-billing-fields .validate-required, .woocommerce-shipping-fields .validate-required');
@@ -157,6 +134,7 @@ jQuery(function ($) {
                 return wc_paylike_form.escapeQoutes(phone);
             },
             onSubmit: function (e) {
+	            if (!wc_paylike_form.validateShipmondo()) return true;
                 if (wc_paylike_form.isPaylikeModalNeeded()) {
                     e.preventDefault();
 
@@ -241,6 +219,43 @@ jQuery(function ($) {
             },
             escapeQoutes:function(str) {
                 return str.toString().replace(/"/g, '\\"');
+            },
+            validateShipmondo:function() {
+	            
+	            // Check if Shipmondo (Pakkelabels.dk) shipping option is selected
+	            if ($('#shipping_method input:checked').val().indexOf("pakkelabels") >= 0) {
+		            
+					// Business shipping, but no business name
+	                var shipmondoBusinessTypes = [
+	                    "pakkelabels_shipping_gls_business",
+	                    "pakkelabels_shipping_postnord_business",
+	                    "pakkelabels_shipping_bring_business"
+	                ];
+	                
+	                if (shipmondoBusinessTypes.includes($('#shipping_method input:checked').val()) && $("#billing_company").val() == '') {
+	                    return false;
+	                }
+	
+					// Pickup point shipping, but no pickup point selected
+	                var shipmondoPickupPointTypes = [
+	                    "pakkelabels_shipping_gls",
+	                    "pakkelabels_shipping_pdk",
+	                    "pakkelabels_shipping_dao",
+	                    "pakkelabels_shipping_bring"
+	                ];
+	                
+					// Check if pickup point shipping is selected
+	                if (shipmondoPickupPointTypes.includes($('#shipping_method input:checked').val())) {
+						// Check if a shopID exists
+		                if ($("#hidden_chosen_shop input[name='shop_ID']").val() == '') {
+	                    	return false;
+	                    }
+	                }
+	                
+	            }
+                
+                return true;
+
             }
         }
     ;

--- a/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
+++ b/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
@@ -52,6 +52,23 @@ jQuery(function ($) {
                 if ($('#createaccount').is(':checked') && $account_password.length && $account_password.val() === '') {
                     return false;
                 }
+                
+                // Shipmondo: Business shipping, but no business name
+                if ($('#shipping_method input:checked').val() == 'pakkelabels_shipping_postnord_business' && $("#billing_company").val() == '') {
+					return false;
+                }
+
+				// Shipmondo: Pickup point shipping, but no pickup point selected
+				var shipmondoPickupPointTypes = [
+					"pakkelabels_shipping_gls",
+					"pakkelabels_shipping_pdk",
+					"pakkelabels_shipping_dao",
+					"pakkelabels_shipping_bring"
+				];
+				
+				if (shipmondoPickupPointTypes.includes($('#shipping_method input:checked').val()) && $("#hidden_chosen_shop input[name='shop_ID']").val() == '') {
+					return false;
+                }
 
                 // check to see if we need to validate shipping address
                 if ($('#ship-to-different-address-checkbox').is(':checked')) {


### PR DESCRIPTION
When using the Paylike integration with the checkout_mode=before_order pickup point selection and business shipping isn't validated before the payment modal is opened.

These changes returns false in isPaylikeModalNeeded if server-side validation is required for shipmondo shipping.