### PR TITLE
Server-side validation before popup is shown

### DIFF
--- a/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
+++ b/woocommerce-gateway-paylike/assets/js/paylike_checkout.js
@@ -176,17 +176,17 @@ jQuery( function( $ ) {
 			},
 			onSubmit: function( e ) {
 
-				//Get checkout form data
+				// Get checkout form data
 				var formData = wc_paylike_form.form.serializeArray();
 
-				//Modify form to sure its just a validation check
+				// Modify form to make sure its just a validation check
 				formData.push({name: "woocommerce_checkout_update_totals", value: true});
 
-				//Show loading indicator
+				// Show loading indicator
 				wc_paylike_form.form.addClass( 'processing' );
 				wc_paylike_form.block();
 
-				//Make request to validate checkout form
+				// Make request to validate checkout form
 				$.ajax({
 					type: 'POST',
 					url: wc_checkout_params.checkout_url,


### PR DESCRIPTION
This modification will submit the checkout form for validation on the server side before the popup is shown. If theres any error, it will display error messages. If theres no error, the payment popup is shown. This fixes issues with third-party plugins that apply custom validation on the checkout form, mainly using the "woocommerce_after_checkout_validation" hook. This hook is used by core WooCommerce too for coupon validation too in some cases. 

To give you an example, EU VAT Number validation is done in this action, but the Paylike popup is shown before the validation is done. So in case of an invalid vat number, Paylike will create a charge in the entered credit card, but the order won't be created due to the validation. I believe the "validateShipmondo" function was created because of this issue too. I think that can be removed as this is an universal solution.